### PR TITLE
fix: correct class name from jun-edgeCollapseTrigger to jun-edgeDrawerTrigger

### DIFF
--- a/content/docs/edge-sidebar.mdx
+++ b/content/docs/edge-sidebar.mdx
@@ -173,7 +173,7 @@ import { triggerEdgeDrawer } from "tailwindcss-jun-layout";
 <div className="jun-layout">
   <header>
     <button
-      className="jun-edgeCollapseTrigger"
+      className="jun-edgeDrawerTrigger"
       onClick={() => triggerEdgeDrawer()}
     >
       Toggle


### PR DESCRIPTION
Change class name from jun-edgeCollapseTrigger to jun-edgeDrawerTrigger in drawer trigger example